### PR TITLE
force timeline svg to take up the whole space it was given

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -418,6 +418,11 @@ body {
   border-right: 1px solid lightgrey;
 }
 
+.timeline-container {
+  height: 100%;
+  width: 100%;
+}
+
 .axis-label {
   font-size: 12px;
   fill: #333;

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
         </div>
 
         <div class="timeline-zone">
-            <div id="timeline-chart"></div>
+            <svg id="timeline-chart" class="timeline-container"></svg>
         </div>
 
     </div>

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -33,6 +33,16 @@ class Timeline {
         vis.width = vis.config.containerWidth - vis.config.margin.left - vis.config.margin.right;
         vis.height = vis.config.containerHeight - vis.config.margin.top - vis.config.margin.bottom;
 
+        // define size of SVG drawing area based on the specified SVG window
+        vis.svg = d3.select(vis.config.parentElement)
+            .attr('width', '100%')
+            .attr('height', '100%')
+            .attr('viewBox', `0 0 ${vis.config.containerWidth} ${vis.config.containerHeight}`)
+            .attr('preserveAspectRatio', 'none');
+
+        vis.svg.append('g')
+            .attr('transform', `translate(${vis.config.margin.left},${vis.config.margin.top})`);
+
         vis.xScale = d3.scaleTime()
             .range([0, vis.width]);
 
@@ -42,13 +52,6 @@ class Timeline {
         vis.xAxis = d3.axisBottom(vis.xScale);
         vis.yAxis = d3.axisLeft(vis.yScale);
 
-        vis.svg = d3.select(vis.config.parentElement)
-            .append('svg')
-            .attr('width', vis.config.containerWidth)
-            .attr('height', vis.config.containerHeight)
-            .append('g')
-            .attr('transform', `translate(${vis.config.margin.left},${vis.config.margin.top})`);
-    
         vis.svg.append('g')
             .attr('class', 'x-axis')
             .attr('transform', `translate(0, ${vis.height})`);


### PR DESCRIPTION
Previous the sizing of the timeline was statically defined. Now it always takes up the size of the container it is in, which is dynamically sized with the grid creation. This just helps create some more visual consistency with it