### PR TITLE
set all barchart defaults to sqrt scale

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -46,11 +46,11 @@ d3.csv('data/Cincinnati_311_(Non-Emergency)_Service_Requests_20260227_subset.csv
         timeline.updateVis();
 
         // Update all bar charts to reflect counts from the active dataset
-        requestsPerNeighborhood = updateBarChart(activeData, 'NEIGHBORHOOD', requestsPerNeighborhood, '#requests-per-neighborhood', 'Neighborhood', 'Service Requests by Neighborhood', 'Requests', 'vertical', 'linear', NEIGHBORHOOD_ABBREVIATIONS, false, d => leafletMap.colorScaleNeighborhood(d), 'neighborhood');
-        requestMethods = updateBarChart(activeData, 'METHOD_RECEIVED', requestMethods, '#request-methods', 'Submission Method', 'Request Submission Methods', 'Requests', 'horizontal', 'linear', null, false, null, null);
-        serviceDeptDistribution = updateBarChart(activeData, 'DEPT_NAME', serviceDeptDistribution, '#service-dept-distribution', 'Public Agency', 'Service Requests by Public Agency', 'Requests', 'horizontal', 'linear', null, true, d => leafletMap.colorScaleAgency(d), 'agency');
-        priorityDistribution = updateBarChart(activeData, 'PRIORITY', priorityDistribution, '#priority-distribution', 'Priority Level', 'Requests by Priority Level', 'Requests', 'horizontal', 'linear', null, false, d => leafletMap.colorScalePriority(d), 'priority');
-        serviceTypeDistribution = updateBarChart(activeData, 'SR_TYPE', serviceTypeDistribution, '#service-type-distribution', 'Service Type', 'Requests by Service Type', 'Requests', 'horizontal', 'linear', null, false, d => leafletMap.colorScaleServiceType(d), 'serviceType');
+        requestsPerNeighborhood = updateBarChart(activeData, 'NEIGHBORHOOD', requestsPerNeighborhood, '#requests-per-neighborhood', 'Neighborhood', 'Service Requests by Neighborhood', 'Requests', 'vertical', 'sqrt', NEIGHBORHOOD_ABBREVIATIONS, false, d => leafletMap.colorScaleNeighborhood(d), 'neighborhood');
+        requestMethods = updateBarChart(activeData, 'METHOD_RECEIVED', requestMethods, '#request-methods', 'Submission Method', 'Request Submission Methods', 'Requests', 'horizontal', 'sqrt', null, false, null, null);
+        serviceDeptDistribution = updateBarChart(activeData, 'DEPT_NAME', serviceDeptDistribution, '#service-dept-distribution', 'Public Agency', 'Service Requests by Public Agency', 'Requests', 'horizontal', 'sqrt', null, true, d => leafletMap.colorScaleAgency(d), 'agency');
+        priorityDistribution = updateBarChart(activeData, 'PRIORITY', priorityDistribution, '#priority-distribution', 'Priority Level', 'Requests by Priority Level', 'Requests', 'horizontal', 'sqrt', null, false, d => leafletMap.colorScalePriority(d), 'priority');
+        serviceTypeDistribution = updateBarChart(activeData, 'SR_TYPE', serviceTypeDistribution, '#service-type-distribution', 'Service Type', 'Requests by Service Type', 'Requests', 'horizontal', 'sqrt', null, false, d => leafletMap.colorScaleServiceType(d), 'serviceType');
     }
 
     // initialize chart and then show it
@@ -71,11 +71,11 @@ d3.csv('data/Cincinnati_311_(Non-Emergency)_Service_Requests_20260227_subset.csv
     timeline.updateVis();
 
     // initialize bar charts
-    requestsPerNeighborhood = updateBarChart(validData, 'NEIGHBORHOOD', requestsPerNeighborhood, '#requests-per-neighborhood', 'Neighborhood', 'Service Requests by Neighborhood', 'Requests', 'vertical', 'linear', NEIGHBORHOOD_ABBREVIATIONS, false, d => leafletMap.colorScaleNeighborhood(d), 'neighborhood');
-    requestMethods = updateBarChart(validData, 'METHOD_RECEIVED', requestMethods, '#request-methods', 'Submission Method', 'Request Submission Methods', 'Requests', 'horizontal', 'linear', null, false, null, null);
-    serviceDeptDistribution = updateBarChart(validData, 'DEPT_NAME', serviceDeptDistribution, '#service-dept-distribution', 'Public Agency', 'Service Requests by Public Agency', 'Requests', 'horizontal', 'linear', null, true, d => leafletMap.colorScaleAgency(d), 'agency');
-    priorityDistribution = updateBarChart(validData, 'PRIORITY', priorityDistribution, '#priority-distribution', 'Priority Level', 'Requests by Priority Level', 'Requests', 'horizontal', 'linear', null, false, d => leafletMap.colorScalePriority(d), 'priority');
-    serviceTypeDistribution = updateBarChart(validData, 'SR_TYPE', serviceTypeDistribution, '#service-type-distribution', 'Service Type', 'Requests by Service Type', 'Requests', 'horizontal', 'linear', null, false, d => leafletMap.colorScaleServiceType(d), 'serviceType');
+    requestsPerNeighborhood = updateBarChart(validData, 'NEIGHBORHOOD', requestsPerNeighborhood, '#requests-per-neighborhood', 'Neighborhood', 'Service Requests by Neighborhood', 'Requests', 'vertical', 'sqrt', NEIGHBORHOOD_ABBREVIATIONS, false, d => leafletMap.colorScaleNeighborhood(d), 'neighborhood');
+    requestMethods = updateBarChart(validData, 'METHOD_RECEIVED', requestMethods, '#request-methods', 'Submission Method', 'Request Submission Methods', 'Requests', 'horizontal', 'sqrt', null, false, null, null);
+    serviceDeptDistribution = updateBarChart(validData, 'DEPT_NAME', serviceDeptDistribution, '#service-dept-distribution', 'Public Agency', 'Service Requests by Public Agency', 'Requests', 'horizontal', 'sqrt', null, true, d => leafletMap.colorScaleAgency(d), 'agency');
+    priorityDistribution = updateBarChart(validData, 'PRIORITY', priorityDistribution, '#priority-distribution', 'Priority Level', 'Requests by Priority Level', 'Requests', 'horizontal', 'sqrt', null, false, d => leafletMap.colorScalePriority(d), 'priority');
+    serviceTypeDistribution = updateBarChart(validData, 'SR_TYPE', serviceTypeDistribution, '#service-type-distribution', 'Service Type', 'Requests by Service Type', 'Requests', 'horizontal', 'sqrt', null, false, d => leafletMap.colorScaleServiceType(d), 'serviceType');
 
     // add the view swapping buttons
     injectSwapButtons();


### PR DESCRIPTION
This is in effort to improve interactions with the bar charts because in a linear scale some bins would become too small to easily interact with. sqrt scale increases the size of these smaller bins while still maintaining some level of shape