### PR TITLE
HOTFIX: keep tooltip anchored to cursor during brush interactions

### DIFF
--- a/js/leafletMap.js
+++ b/js/leafletMap.js
@@ -165,8 +165,8 @@ class LeafletMap {
                 d3.select('#tooltip')
                     .style('opacity', 1)
                     .style('left', (event.pageX + 10) + 'px')
-          .style('top', (event.pageY + 10) + 'px')
-          .html(`
+                    .style('top', (event.pageY + 10) + 'px')
+                    .html(`
                         <div class="tooltip-content">
                             <strong>Type:</strong> ${d.SR_TYPE}<br>
                             <strong>Description:</strong> ${d.SR_TYPE_DESC}<br>
@@ -175,7 +175,6 @@ class LeafletMap {
                             <strong>Last Updated:</strong> ${d.DATE_LAST_UPDATE}
                         </div>
                     `);
-      
             })
             .on('mousemove', function(event) {
                 // position the tooltip
@@ -209,13 +208,13 @@ class LeafletMap {
         vis.brushG.call(vis.brush);
         vis.brushG.style('display', 'none');
     
-    // During a brush drag the overlay captures mousemove, so dot handlers stop firing.
-    // This listener on the brush group keeps the tooltip position updated during drags.
-    vis.brushG.on('mousemove.tooltip', function(event) {
-      d3.select('#tooltip')
-        .style('left', (event.pageX + 10) + 'px')
-        .style('top', (event.pageY + 10) + 'px');
-    });
+        // During a brush drag the overlay captures mousemove, so dot handlers stop firing.
+        // This listener on the brush group keeps the tooltip position updated during drags.
+        vis.brushG.on('mousemove.tooltip', function(event) {
+            d3.select('#tooltip')
+                .style('left', (event.pageX + 10) + 'px')
+                .style('top', (event.pageY + 10) + 'px');
+        });
 
         vis.theMap.on('resize', () => {
             vis.resizeHeatmapCanvas();
@@ -729,8 +728,8 @@ class LeafletMap {
                     d3.select('#tooltip')
                         .style('opacity', 1)
                         .style('left', (event.pageX + 10) + 'px')
-            .style('top', (event.pageY + 10) + 'px')
-            .html(`
+                        .style('top', (event.pageY + 10) + 'px')
+                        .html(`
                             <div class="tooltip-content">
                                 <strong>${type} includes:</strong><br>
                                 ${subtypes.map(s => `&bull; ${s}`).join('<br>')}

--- a/js/leafletMap.js
+++ b/js/leafletMap.js
@@ -158,13 +158,15 @@ class LeafletMap {
             .attr('base-r', vis.dynamicRadius)
             .attr('r', vis.dynamicRadius)
             .attr('class', d => `dot request-${d.SR_NUMBER}`)
-            .on('mouseover', function (event, d) { 
+            .on('mouseover', function (event, d) {
                 highlightRequest(d.SR_NUMBER);
       
                 // create a tool tip
                 d3.select('#tooltip')
                     .style('opacity', 1)
-                    .html(`
+                    .style('left', (event.pageX + 10) + 'px')
+          .style('top', (event.pageY + 10) + 'px')
+          .html(`
                         <div class="tooltip-content">
                             <strong>Type:</strong> ${d.SR_TYPE}<br>
                             <strong>Description:</strong> ${d.SR_TYPE_DESC}<br>
@@ -175,7 +177,7 @@ class LeafletMap {
                     `);
       
             })
-            .on('mousemove', (event) => {
+            .on('mousemove', function(event) {
                 // position the tooltip
                 d3.select('#tooltip')
                     .style('left', (event.pageX + 10) + 'px')
@@ -207,6 +209,14 @@ class LeafletMap {
         vis.brushG.call(vis.brush);
         vis.brushG.style('display', 'none');
     
+    // During a brush drag the overlay captures mousemove, so dot handlers stop firing.
+    // This listener on the brush group keeps the tooltip position updated during drags.
+    vis.brushG.on('mousemove.tooltip', function(event) {
+      d3.select('#tooltip')
+        .style('left', (event.pageX + 10) + 'px')
+        .style('top', (event.pageY + 10) + 'px');
+    });
+
         vis.theMap.on('resize', () => {
             vis.resizeHeatmapCanvas();
             vis.refreshBrushExtent();
@@ -715,10 +725,12 @@ class LeafletMap {
             row.append('span')
                 .attr('class', 'legend-info-icon')
                 .html(infoSvg)
-                .on('mouseover', function() {
+                .on('mouseover', function(event) {
                     d3.select('#tooltip')
                         .style('opacity', 1)
-                        .html(`
+                        .style('left', (event.pageX + 10) + 'px')
+            .style('top', (event.pageY + 10) + 'px')
+            .html(`
                             <div class="tooltip-content">
                                 <strong>${type} includes:</strong><br>
                                 ${subtypes.map(s => `&bull; ${s}`).join('<br>')}


### PR DESCRIPTION
I noticed a bug where the tooltips for the dots in the leaflet map were getting locked up in weird positions. This fixes that but reintroduces the tooltips showing up while the brushing window is being drawn... seems like a worthy tradeoff to me.

@isaac-dowdy lmk your thoughts 